### PR TITLE
Reads private key data into memory to feed it to the jwtBuilder

### DIFF
--- a/bin/jwtgen.js
+++ b/bin/jwtgen.js
@@ -8,6 +8,8 @@ const yargs = require( 'yargs' );
 
 const jwtBuilder = require( 'jwt-builder' );
 
+const fs = require( 'fs' );
+
 const argv = yargs.usage( 'Usage: $0 [options]' )
 
     .demand( 'a' )
@@ -165,7 +167,8 @@ if( argv.a === 'RS256' ) {
         exitError( 'private key missing' );
     }
 
-    builder.privateKeyFromPath( argv.p );
+    var keyData = fs.readFileSync( argv.p ).toString();
+    builder.privateKey( keyData );
 }
 else {
 


### PR DESCRIPTION
Fixes #4

The function `privateKeyFromPath` does not exists and because of that it is not possible to use the RS256 which requires a private key on a file.

This change reads the content of the private key 